### PR TITLE
Allow directory to be provided as final arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ brew install gitclean
 $ gitclean # executes "git branch -d" on ": gone" branches
 ```
 
-**With force delete:**
+### With force delete
 
 ```bash
 $ gitclean -f # same as above, but with "-D" instead of "-d"
@@ -27,7 +27,7 @@ $ gitclean -f # same as above, but with "-D" instead of "-d"
 $ gitclean --force
 ```
 
-**Interactive**
+### Interactive
 
 Present all ": gone" branches in a checkbox list, allowing user to opt-in to deletions.
 
@@ -35,8 +35,18 @@ Present all ": gone" branches in a checkbox list, allowing user to opt-in to del
 $ gitclean -i
 # or
 $ gitclean --interactive
-# with force:
+# with force
 $ gitclean -if
 # or
 $ gitclean --interactive --force
+```
+
+### Directory
+
+By default, `gitclean` will execute all commands in the **current directory** (`.`), however, you can pass a path to another git repository after any/all other flags.
+
+```bash
+$ gitclean ../some/other/repo
+# with flags
+$ gitclean -if ../some/other/repo
 ```

--- a/git/git.go
+++ b/git/git.go
@@ -19,6 +19,13 @@ type Git struct {
 
 	DeletedBranches      []string
 	BranchDeletionErrors []branchDeletionError
+
+	directory string
+}
+
+// NewExecutor Constructor for git executor
+func NewExecutor(directory string) Git {
+	return Git{directory: directory}
 }
 
 func reportProcess(name string) {
@@ -26,7 +33,8 @@ func reportProcess(name string) {
 }
 
 func (g *Git) execGitCommand(args []string) {
-	cmd := exec.Command("git", args...)
+	argsWithDirectory := append([]string{"-C", g.directory}, args...)
+	cmd := exec.Command("git", argsWithDirectory...)
 	var out bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &out

--- a/main.go
+++ b/main.go
@@ -38,7 +38,12 @@ func main() {
 		return
 	}
 
-	git := gUtils.Git{}
+	directory := flag.Arg(0) // first trailing argument after flags (if any)
+	if directory == "" {
+		directory = "."
+	}
+
+	git := gUtils.NewExecutor(directory)
 
 	goneBranches := []string{}
 	branchesToDelete := []string{}


### PR DESCRIPTION
- Git now has a constructor that takes a directory
- Directory is used for every command executed by `execGitCommand`
- Pass `flag.Arg(0)` to new Git constructor in `main`